### PR TITLE
Add Metadata

### DIFF
--- a/vse/pretty_img.py
+++ b/vse/pretty_img.py
@@ -10,6 +10,19 @@ from bpy_extras.io_utils import ImportHelper
 ## dimensions instead of default settings and wonkily stretched/squashed dimensions
 ##
 
+bl_info = {
+    "name": "Pretty Image Loader",
+    "description": "Loads prettier images with transparency and original image.",
+    "author": "Joshua R",
+    "version": (1, 0, 0),
+    "blender": (2, 79, 0),
+    "location": "Sequencer > Strip Properties",
+    "tracker_url": "https://github.com/Botmasher/blender-vse-customizations/issues",
+    "wiki_url": "",
+    "support": "COMMUNITY",
+    "category": "VSE"
+}
+
 def load_scale_img (name, path, scale=1.0, channel=1, length=10, alpha=True):
 
     scene = bpy.context.scene


### PR DESCRIPTION
Makes the add-on installable. 
https://wiki.blender.org/wiki/Process/Addons/Guidelines/metainfo

You properly know about this, but for newcomers, this may be the difference between "working" and not "working". I hope that's okay?

Add-on works fine now. Getting the source dimensions shouldn't be this complicated, maybe file a bug here: https://developer.blender.org/project/view/28/

Actually, there is a request at right-click select for this fix/add-on: https://blender.community/c/rightclickselect/GXbbbc/vse-aspect-correction